### PR TITLE
Fix rotation matrix indexing for rectangular kernels

### DIFF
--- a/se2cnn/rotation_matrix.py
+++ b/se2cnn/rotation_matrix.py
@@ -127,10 +127,10 @@ def ToLinearIndex(ij, NiNj):
               domain as [Ni,Nj]
 
         OUTPUT:
-            - ijFlat = ij[0] * NiNj[0] + ij[1]
+            - ijFlat = ij[0] * NiNj[1] + ij[1]
     """
 
-    return ij[0] * NiNj[0] + ij[1]
+    return ij[0] * NiNj[1] + ij[1]
 
 
 def RotationOperatorMatrix(NiNj, theta, diskMask=True):
@@ -154,14 +154,16 @@ def RotationOperatorMatrix(NiNj, theta, diskMask=True):
     # Image size
     Ni = NiNj[0]
     Nj = NiNj[1]
-    cij = m.floor(Ni / 2)  # center
+    ci = m.floor(Ni / 2)
+    cj = m.floor(Nj / 2)
+    radius = min(ci, cj)
 
     # Fill the rotation operator matrix
     rotationMatrix = np.zeros([Ni * Nj, Ni * Nj])
     for i in range(0, NiNj[0]):
-        for j in range(0, NiNj[0]):
+        for j in range(0, NiNj[1]):
             # Apply a circular mask (disk matrix) if desired
-            if not(diskMask) or ((i - cij) * (i - cij) + (j - cij) * (j - cij) <= (cij + 0.5) * (cij + 0.5)):
+            if (not diskMask) or ((i - ci) * (i - ci) + (j - cj) * (j - cj) <= (radius + 0.5) * (radius + 0.5)):
                 # The row index of the operator matrix
                 linij = ToLinearIndex([i, j], NiNj)
                 # The interpolation points
@@ -230,16 +232,18 @@ def RotationOperatorMatrixSparse(NiNj, theta, diskMask=True, linIndOffset=0):
     # Image size
     Ni = NiNj[0]
     Nj = NiNj[1]
-    cij = m.floor(Ni / 2)  # center
+    ci = m.floor(Ni / 2)
+    cj = m.floor(Nj / 2)
+    radius = min(ci, cj)
 
     # Fill the rotation operator matrix
     # rotationMatrix = np.zeros([Ni * Nj, Ni * Nj])
-    idx = [] # This will contain a list of index tuples
-    vals = [] # This will contain the corresponding weights
+    idx = []  # This will contain a list of index tuples
+    vals = []  # This will contain the corresponding weights
     for i in range(0, NiNj[0]):
-        for j in range(0, NiNj[0]):
+        for j in range(0, NiNj[1]):
             # Apply a circular mask (disk matrix) if desired
-            if not(diskMask) or ((i - cij) * (i - cij) + (j - cij) * (j - cij) <= (cij + 0.5) * (cij + 0.5)):
+            if (not diskMask) or ((i - ci) * (i - ci) + (j - cj) * (j - cj) <= (radius + 0.5) * (radius + 0.5)):
                 # The row index of the operator matrix
                 linij = ToLinearIndex([i, j], NiNj)
                 # The interpolation points

--- a/tests/test_rotation_matrix.py
+++ b/tests/test_rotation_matrix.py
@@ -1,0 +1,22 @@
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+import numpy as np
+
+rotation_matrix = SourceFileLoader(
+    "rotation_matrix", str(Path(__file__).resolve().parent.parent / "se2cnn" / "rotation_matrix.py")
+).load_module()
+ToLinearIndex = rotation_matrix.ToLinearIndex
+RotationOperatorMatrixSparse = rotation_matrix.RotationOperatorMatrixSparse
+
+
+def test_to_linear_index_rectangular():
+    assert ToLinearIndex([1, 2], [2, 3]) == 1 * 3 + 2
+
+
+def test_rotation_operator_matrix_sparse_identity():
+    idx, vals = RotationOperatorMatrixSparse([2, 3], 0.0, diskMask=False)
+    size = 2 * 3
+    dense = np.zeros((size, size))
+    for (row, col), val in zip(idx, vals):
+        dense[row, col] = val
+    assert np.allclose(dense, np.eye(size))


### PR DESCRIPTION
## Summary
- Correct rotation matrix utilities to iterate over both height and width separately and compute linear indices using width
- Add tests ensuring rotation kernels behave correctly on non-square domains

## Testing
- `python -m pytest tests/test_rotation_matrix.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688e6859482483239e07993c77686ab8